### PR TITLE
Fix Windows compilation error - e_compression.c

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,0 +1,11 @@
+Contributors
+------------
+
+* Burnett, Mitch
+* Euler, Garrett
+* Gammans, Christine
+* MacCarthy, Jonathan
+* Marcillo, Omar
+* Stead, Richard
+* Webster, Jeremy
+* Young, Brian

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 
 # CHANGELOG
 
+## 0.1.2
+
+* Added a module definition to `e_compression.c`. This formally defines the lbrary as a Python module, fixing the `error LNK2001: unresolved external symbol PyInit__libe1` that occurs on Windows and allows it to compile correctly.
+* Changed the method for determining compiled Python module file extensions in `setup.py` from `sysconfig.get_config_vars()` to `importlib.machinery`, which should fix importing problems on Python 3.6 and 3.7.
+
 ## 0.1.1
 
 * Add tests

--- a/e1.py
+++ b/e1.py
@@ -4,11 +4,11 @@ e1 : Python support for the e1 compression format
 """
 import ctypes as C
 import os
-import sysconfig
+import importlib.machinery
 
 import numpy as np
 
-ext, = sysconfig.get_config_vars('SO')
+ext = importlib.machinery.EXTENSION_SUFFIXES[0]
 libecomp = C.CDLL(os.path.dirname(__file__) + os.path.sep + '_libe1' + ext)
 libecomp.e_decomp.restype = C.c_int
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open('README.md') as readme:
 doclines = __doc__.split("\n")
 
 setup(name='e1',
-      version='0.1.1',
+      version='0.1.2',
       description='Python support for the e1 compression format.',
       long_description=long_description,
       long_description_content_type="text/markdown", # setuptools >= 38.6.0

--- a/src/e_compression.c
+++ b/src/e_compression.c
@@ -64,15 +64,36 @@
 #define EC_MAKECHECK(x) ((((x) & 0x00ffffff) << 8) >> 8)
 
 
-/* Python C extensions for Windows expects the symbol initModuleName when building the library.
-* This declaration gives msvc compiler this symbol to compile correctly.
-* Note : This not the documented way to build C extensions for Windows. It is typically expected to
-* use wrapper methods. What this does is prevents a statement such as 'import libecompression' in Python.
-* Instead, the only way to load the library is through a ctypes.CDLL call. Which in this case, is all that
-* is needed as seen in readwaveform.py.
+/* Initialize a bare-bones Python module. This module isn't meant to be used directly, but rather it is
+* interacted with through a ctypes.CDLL call. However, particularly on Windows, a module definition is
+* required to get this file to compile.
 */
 #ifdef _WIN32
-void initlibecompression(){}
+PyMODINIT_FUNC PyInit__libe1(void)
+{
+  /* define a basic PyObject with just a name and docstring */
+  PyObject *m;
+  static struct PyModuleDef mdef = {
+    PyModuleDef_HEAD_INIT,
+    "_libe1",                       /* name */
+     "Library for e1 compression",  /* docstring */
+     -1,                            /* size */
+     NULL,                          /* methods */
+     NULL,                          /* reload */
+     NULL,                          /* traverse */
+     NULL,                          /* clear */
+     NULL                           /* free */
+  };
+  
+  /* create the module described above */
+  m = PyModule_Create(&mdef);
+  
+  /* return */
+  if (!m)
+    return NULL;
+  else
+    return m;
+}
 #endif
 
 /*


### PR DESCRIPTION
From my Googling, since Python 3, CPython modules supposedly *require* a PyMODINIT statement. The lack of this statement resulted in a failure to compile this module on Windows with "error LNK2001: unresolved external symbol PyInit__libe1". Given that the module definition is required, I don’t know why Windows was failing to compile it while it worked on Mac/Linux. Regardless, this change appears to fix the compiling error on Windows.

In testing, a simple statement that returns NULL will suffice...
```c
PyMODINIT_FUNC PyInit__libe1(void){return NULL;}
```
...but that seems particularly hack-ey and prone to future breakage, so I opted to define a methodless PyObject, instead.

EDIT:
Closes #1 
Closes LANL-Seismoacoustics/pisces#29 LANL-Seismoacoustics/pisces#37